### PR TITLE
gosa.conf: Use same privacyIDEA variables (server, account details, r…

### DIFF
--- a/personal/privacyidea/class_PrivacyIdeaUtils.inc
+++ b/personal/privacyidea/class_PrivacyIdeaUtils.inc
@@ -64,10 +64,10 @@ class PrivacyIdeaUtils implements PILog
 
         $this->GOSA_SETTINGS_GROUP = get_class($mfaAccount);
 
-        $piServerUrl = $this->getConfigStrValue("privacyIdeaServerUrl");
-        $this->authUsername = $this->getConfigStrValue("serviceAccountUsername");
-        $this->authPassword = $this->getConfigStrValue("serviceAccountPassword");
-        $this->authRealm    = $this->getConfigStrValue("serviceAccountRealm");
+        $piServerUrl = $this->getConfigStrValue("piServer");
+        $this->authUsername = $this->getConfigStrValue("piServiceAccount");
+        $this->authPassword = $this->getConfigStrValue("piServicePass");
+        $this->authRealm    = $this->getConfigStrValue("piRealm");
 
         $this->pi = new PrivacyIDEA($_SERVER['HTTP_USER_AGENT'], $piServerUrl);
         // $this->pi->logger = $this; // Needs $this->piDebug() and $this->piError().

--- a/personal/privacyidea/class_mfaAccount.inc
+++ b/personal/privacyidea/class_mfaAccount.inc
@@ -731,7 +731,7 @@ class mfaAccount extends plugin
     {
         $privacyidea_settings = array(
             array(
-                "name"        => "privacyIdeaServerUrl",
+                "name"        => "piServer",
                 "type"        => "string",
                 "check"       => "gosaProperty::isString",
                 "group"       => "privacyidea",
@@ -741,7 +741,7 @@ class mfaAccount extends plugin
                 "description" => _("PrivacyIDEA server URL.")
             ),
             array(
-                "name"        => "serviceAccountUsername",
+                "name"        => "piServiceAccount",
                 "type"        => "string",
                 "check"       => "gosaProperty::isString",
                 "group"       => "privacyidea",
@@ -751,7 +751,7 @@ class mfaAccount extends plugin
                 "description" => _("PrivacyIDEA service account username. Used to authenticate against PrivacyIDEA.")
             ),
             array(
-                "name"        => "serviceAccountPassword",
+                "name"        => "piServicePass",
                 "type"        => "string",
                 "check"       => "gosaProperty::isString",
                 "group"       => "privacyidea",
@@ -761,7 +761,7 @@ class mfaAccount extends plugin
                 "description" => _("PrivacyIDEA service account password. Used to authenticate against PrivacyIDEA.")
             ),
             array(
-                "name"        => "serviceAccountRealm",
+                "name"        => "piRealm",
                 "type"        => "string",
                 "check"       => "gosaProperty::isString",
                 "group"       => "privacyidea",


### PR DESCRIPTION
…ealm) as gosa-core.