### PR TITLE
personal/privacyidea/class_{mfaAccount,PrivacyIdeaUtils}.inc: Rename …

### DIFF
--- a/personal/privacyidea/class_PrivacyIdeaUtils.inc
+++ b/personal/privacyidea/class_PrivacyIdeaUtils.inc
@@ -67,7 +67,7 @@ class PrivacyIdeaUtils implements PILog
         $piServerUrl = $this->getConfigStrValue("piServer");
         $this->authUsername = $this->getConfigStrValue("piServiceAccount");
         $this->authPassword = $this->getConfigStrValue("piServicePass");
-        $this->authRealm    = $this->getConfigStrValue("piRealm");
+        $this->authRealm    = $this->getConfigStrValue("piServiceRealm");
 
         $this->pi = new PrivacyIDEA($_SERVER['HTTP_USER_AGENT'], $piServerUrl);
         // $this->pi->logger = $this; // Needs $this->piDebug() and $this->piError().

--- a/personal/privacyidea/class_mfaAccount.inc
+++ b/personal/privacyidea/class_mfaAccount.inc
@@ -753,7 +753,7 @@ class mfaAccount extends plugin
                 "description" => _("PrivacyIDEA service account password. Used to authenticate against PrivacyIDEA.")
             ),
             array(
-                "name"        => "piRealm",
+                "name"        => "piServiceRealm",
                 "type"        => "string",
                 "check"       => "gosaProperty::isString",
                 "group"       => "privacyidea",


### PR DESCRIPTION
…piRealm to piServiceRealm.

This requires a similar renaming in gosa-core. We in fact need to honour the possibility of operating on (at least) two different realms:

  * One realm (piUserRealm) for the LDAP users / privacyIDEA accounts.
  * One realm (piServiceRealm) for the privacyIDEA admin account that GOsa² needs to execute operation on behalf of GOsa² users.