### PR TITLE
personal/privacyidea/default/mfa_intro.tpl: Make allowedTokenTypes ed…

### DIFF
--- a/personal/privacyidea/default/mfa_intro.tpl
+++ b/personal/privacyidea/default/mfa_intro.tpl
@@ -56,7 +56,6 @@
 </div>
 {/render}
 
-{if $parent == "roletabs"}
 {render acl=$allowedTokenTypesACL}
 <h2>{t}Allowed factors{/t}</h2>
 <div class="row">
@@ -71,7 +70,6 @@
     </div>
 </div>
 {/render}
-{/if}
 
 {* If no token is registered, warn the user! *}
 {if $parent == "usertabs" && $showWarningNoTokenRegistered}


### PR DESCRIPTION
…itable on a per user basis.

The allowedTokenTypes field should be editable on a per-user basis and on a per-role basis. If either of that is not wanted, it should be disabled via the corresponding ACL(s).