### PR TITLE
class_PrivacyIdeaUtils.inc: Use <config.class>->get_cfg_value_ext() i…

### DIFF
--- a/personal/privacyidea/class_PrivacyIdeaUtils.inc
+++ b/personal/privacyidea/class_PrivacyIdeaUtils.inc
@@ -674,7 +674,7 @@ class PrivacyIdeaUtils implements PILog
 
         // Get config value from LDAP tree, gosa config file (gosa.conf) or
         // defaults from class_mfaAccount.inc
-        $ret = $this->config->get_cfg_value("core", $key);
+        $ret = $this->config->get_cfg_value_ext("core", $key);
 
         if ($debug_to_jsconsole) {
             // Debug property to js console (if debugging is enabled!).


### PR DESCRIPTION
…nstead of <config.class>->get_cfg_value().

Where as get_cfg_value() tries to use the GOsa² property system, get_cfg_value_ext() directly reads from the gosa.conf config file.

This avoids log messages of the kind:

| debug | warning | Unconfigured property: 'core::pi<SomeThing>'

As a side note, this is wanted behaviour. The privacyIDEA service account settings (et al.) shall not be stored in LDAP. They shall always be obtained from the gosa.conf file, so it requires someone with filesystem access to tinker with them.