### PR TITLE
PrivacyIdeaUtils: Turn off ENABLE_DEBUG_JS_CONSOLE. (Stops stuff from…

### DIFF
--- a/personal/privacyidea/class_PrivacyIdeaUtils.inc
+++ b/personal/privacyidea/class_PrivacyIdeaUtils.inc
@@ -38,7 +38,8 @@ class PrivacyIdeaUtils implements PILog
     private config $config;
     private mfaAccount $mfaAccount;
     // TODO: Replace with GOsa's development mode.
-    private bool $ENABLE_DEBUG_JS_CONSOLE = true;
+    // WARNING: Setting ENABLE_DEBUG_JS_CONSOLE=true leaks PI serviceAccount creds to the client (via JS console).
+    private bool $ENABLE_DEBUG_JS_CONSOLE = false;
 
     /** @var array Token counts array ('all' => X, 'paper' => X, 'totp' => X...) */
     public $tokenCounts;


### PR DESCRIPTION
… being printed in JS console client-side).

WARNING: Setting ENABLE_DEBUG_JS_CONSOLE=true leaks PI serviceAccount creds to the client.