### PR TITLE
class_mfaAccount.inc,default/mfa_batchConfirm.tpl: Set smarty variabl…

### DIFF
--- a/personal/privacyidea/class_mfaAccount.inc
+++ b/personal/privacyidea/class_mfaAccount.inc
@@ -733,6 +733,8 @@ class mfaAccount extends plugin
         assert((is_array($mfaTokens) && array_is_list($mfaTokens)) || is_string($mfaTokens));
 
         $isBatch = is_array($mfaTokens);
+        $this->smarty->assign("isBatch", $isBatch);
+
         $tokenCount = $isBatch ? count($mfaTokens) : 1;
 
         $this->smarty->assign($isBatch ? "mfaTokenBatchAction" : "mfaTokenAction", $mfaTokenAction);

--- a/personal/privacyidea/default/mfa_batchConfirm.tpl
+++ b/personal/privacyidea/default/mfa_batchConfirm.tpl
@@ -25,12 +25,7 @@
 {$mfa_webauthn_icon=usb}
 
 <h2>{$confirmationPrompt}</h2>
-{if isset($mfaTokenAction)}
-    <input type="hidden" name="mfaTokenAction" value="{$mfaTokenAction}">
-    {assign var="description" value="{$serialsTokens[$tokenSerial]['description']}"}
-    <input type="hidden" name="tokenSerial" value="{$tokenSerial}">
-    <p><b>{if !empty($description)}{$description} ({$tokenSerial}){else}{$tokenSerial}{/if}</b></p>
-{else}
+{if $isBatch}
     <input type="hidden" name="mfaTokenBatchAction" value="{$mfaTokenBatchAction}">
     <ul class="browser-default">
         {foreach $mfaTokenSerials as $tokenSerial}
@@ -38,6 +33,11 @@
             <li><input type="hidden" name="mfaTokenSerials[]" value="{$tokenSerial}"><b>{if !empty($description)}{$description} ({$tokenSerial}){else}{$tokenSerial}{/if}</b></li>
         {/foreach}
     </ul>
+{else}
+    <input type="hidden" name="mfaTokenAction" value="{$mfaTokenAction}">
+    {assign var="description" value="{$serialsTokens[$tokenSerial]['description']}"}
+    <input type="hidden" name="tokenSerial" value="{$tokenSerial}">
+    <p><b>{if !empty($description)}{$description} ({$tokenSerial}){else}{$tokenSerial}{/if}</b></p>
 {/if}
 
 <div class="section">


### PR DESCRIPTION
…e for distingushing batch operations

This fixes a bug where the confirmation page would only show a single token serial during batch operations.