### PR TITLE
class_mfaAccount.inc: Also always re-index allowedTokenTypes.

### DIFF
--- a/personal/privacyidea/class_mfaAccount.inc
+++ b/personal/privacyidea/class_mfaAccount.inc
@@ -530,6 +530,9 @@ class mfaAccount extends plugin
             }
         }
 
+        /* Re-index the error, so index numbers always start with number 0 ... */
+        $this->allowedTokenTypes = array_values($this->allowedTokenTypes);
+
         $this->effectiveTokenTypes = array_unique(array_merge($this->allowedTokenTypes, $overrideTokenTypes));
     }
 


### PR DESCRIPTION
See fd75c6b11c6bbdb3210be89cd0126059fb28459c.

This resolves occasional failures in LDAP write operations (depending on the click order in allowedTokenTypes checkboxes).