### PR TITLE
PrivacyIdeaUtils: Do not show multiple error message if PI server was…

### DIFF
--- a/personal/privacyidea/class_PrivacyIdeaUtils.inc
+++ b/personal/privacyidea/class_PrivacyIdeaUtils.inc
@@ -189,6 +189,9 @@ class PrivacyIdeaUtils implements PILog
                 _("Could not get authentification token from privacyIDEA backend server.") . "<br>" .
                 $this->pleaseTryAgainMsg()
             );
+            $this->authToken = "";
+            $this->hasPiErrors = true;
+            return false;
         }
 
         if (!empty($retString)) {
@@ -202,6 +205,7 @@ class PrivacyIdeaUtils implements PILog
                 $this->pleaseTryAgainMsg()
             );
             $this->authToken = "";
+            $this->hasPiErrors = true;
         }
 
         return false;


### PR DESCRIPTION
… unavailable; Also set hasPiErrors=true.

$hasPiErrors is currently used to show an error box instead of an empty token list in mfa_intro.tpl.