### PR TITLE
class_mfaAccount.inc: Initialize allowedTokenTypes / mfaRequired prop…

### DIFF
--- a/personal/privacyidea/class_mfaAccount.inc
+++ b/personal/privacyidea/class_mfaAccount.inc
@@ -90,8 +90,8 @@ class mfaAccount extends plugin
             $this->ldapinfo = [];
         }
 
-        $this->allowedTokenTypes = $this->attrs['allowedTokenTypes'];
-        $this->mfaRequired       = $this->attrs['mfaRequired'];
+        $this->allowedTokenTypes = $this->attrs['allowedTokenTypes'] ?? array();
+        $this->mfaRequired       = $this->attrs['mfaRequired'] ?? array();
 
         $this->effectiveTokenTypes = [];
 


### PR DESCRIPTION
…erties as empty arrays if not-yet-set in LDAP.

This silences:

```
PHP error: Undefined array key "allowedTokenTypes" (<BASEPATH>/plugins/gosa_plugin_privacyidea/personal/privacyidea/class_mfaAccount.inc, line 93)
PHP error: Undefined array key "mfaRequired" (<BASEPATH>/plugins/gosa_plugin_privacyidea/personal/privacyidea/class_mfaAccount.inc, line 94)
```